### PR TITLE
Abstract out Accept* values

### DIFF
--- a/src/Request/Accept/Set.php
+++ b/src/Request/Accept/Set.php
@@ -1,0 +1,162 @@
+<?php
+namespace Aura\Web\Request\Accept;
+
+class Set implements \IteratorAggregate, \Countable, \ArrayAccess {
+    protected $values = array();
+
+    /**
+     * @param string|array $values $_SERVER of an Accept* value
+     * @param string $key The key to look up in $_SERVER.
+     */
+    public function __construct($values = null, $key = null)
+    {
+        if (!is_null($values)) {
+            $this->addValues($values, $key);
+        }
+    }
+
+    /**
+     * @param string|array $values $_SERVER of an Accept* value
+     * @param string $key The key to look up in $_SERVER.
+     */
+    public function addValues($values, $key)
+    {
+        if (is_array($values)) {
+            if (!isset($values[$key])) {
+                $this->values = array();
+                return;
+            }
+            $values = $values[$key];
+        }
+
+        $values = $this->parseValues($values, $key);
+        $values = $this->qualitySort(array_merge($this->values, $values));
+
+        $values = $this->removeDuplicates($values);
+
+        $this->values = $values;
+    }
+
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    public function getValuesAsString()
+    {
+        foreach ($this->values as $value) {
+            $values[] = $value->getValue();
+        }
+
+        return implode(',', $values);
+    }
+
+    protected function parseValues($values, $key)
+    {
+        $parts = explode('_', $key);
+        $class = 'Aura\Web\Request\Accept\Value\\' . ucfirst(strtolower(end($parts)));
+
+        if (!class_exists($class)) {
+            $class = '\Aura\Web\Request\Accept\Value';
+        }
+
+        $values = explode(',', $values);
+
+        foreach ($values as &$value) {
+            $pairs = explode(';', $value);
+            $value = $pairs[0];
+            unset($pairs[0]);
+
+            $params = array();
+            foreach ($pairs as $pair) {
+                $param = array();
+                preg_match('/^(?P<name>.+?)=(?P<quoted>"|\')?(?P<value>.*?)(?:\k<quoted>)?$/', $pair, $param);
+
+                $params[$param['name']] = $param['value'];
+            }
+
+            $priority = 1.0;
+            if (isset($params['q'])) {
+                $priority = $params['q'];
+                unset($params['q']);
+            }
+
+            $obj = new $class();
+            $obj->setValue(trim($value));
+            $obj->setPriority((float) $priority);
+            $obj->setParameters($params);
+            $value = $obj;
+        }
+
+        return $values;
+    }
+
+    protected function qualitySort($values)
+    {
+        $var    = array();
+        $bucket = array();
+
+        // sort into q-value buckets
+        foreach ($values as $value) {
+            $bucket[$value->getPriority()][] = $value;
+        }
+
+        // reverse-sort the buckets so that q=1 is first and q=0 is last,
+        // but the values in the buckets stay in the original order.
+        krsort($bucket);
+
+        // flatten the buckets into the var
+        foreach ($bucket as $q => $values) {
+            foreach ($values as $value) {
+                $var[] = $value;
+            }
+        }
+
+        return $var;
+    }
+
+    protected function removeDuplicates($values)
+    {
+        $unique = array();
+        foreach ($values as $value) {
+            $unique[$value->getValue()] = $value;
+        }
+
+        return array_values($unique);
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->values);
+    }
+
+    public function __toString()
+    {
+        return $this->getValuesAsString();
+    }
+
+    public function count()
+    {
+        return sizeof($this->values);
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->values[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->values[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->values[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->values[$offset]);
+    }
+}

--- a/src/Request/Accept/Value.php
+++ b/src/Request/Accept/Value.php
@@ -1,0 +1,61 @@
+<?php
+namespace Aura\Web\Request\Accept;
+
+class Value {
+    protected $value = "";
+    protected $priority = 1.0;
+    protected $parameters = array();
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param int $priority
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPriority()
+    {
+        return (float) $this->priority;
+    }
+
+    /**
+     * @param array $parameters
+     */
+    public function setParameters($parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    public function __toString()
+    {
+        return $this->getValue();
+    }
+}

--- a/src/Request/Accept/Value/Accept.php
+++ b/src/Request/Accept/Value/Accept.php
@@ -1,0 +1,56 @@
+<?php
+namespace Aura\Web\Request\Accept\Value;
+
+class Accept extends \Aura\Web\Request\Accept\Value {
+    protected $type = '*';
+    protected $subtype = '*';
+
+    /**
+     * @param string $subtype
+     */
+    public function setSubtype($subtype)
+    {
+        $this->subtype = $subtype;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubtype()
+    {
+        return $this->subtype;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getValue()
+    {
+        return $this->type. '/' .$this->subtype;
+    }
+
+    public function setValue($value)
+    {
+        list($this->type, $this->subtype) = explode('/', $value);
+    }
+
+    public function __toString()
+    {
+        $parameters = (sizeof($this->parameters) > 0) ? ';' . http_build_query($this->getParameters(), null, ';') : '';
+
+        return $this->getValue() . ';q=' . $this->priority . $parameters;
+    }
+}

--- a/src/Request/Accept/Value/Charset.php
+++ b/src/Request/Accept/Value/Charset.php
@@ -1,0 +1,6 @@
+<?php
+namespace Aura\Web\Request\Accept\Value;
+
+class Charset extends \Aura\Web\Request\Accept\Value  {
+
+}

--- a/src/Request/Accept/Value/Encoding.php
+++ b/src/Request/Accept/Value/Encoding.php
@@ -1,0 +1,6 @@
+<?php
+namespace Aura\Web\Request\Accept\Value;
+
+class Encoding extends \Aura\Web\Request\Accept\Value  {
+
+}

--- a/src/Request/Accept/Value/Language.php
+++ b/src/Request/Accept/Value/Language.php
@@ -1,0 +1,57 @@
+<?php
+namespace Aura\Web\Request\Accept\Value;
+
+class Language extends \Aura\Web\Request\Accept\Value  {
+    protected $type = '*';
+    protected $subtype = false;
+
+    /**
+     * @param string $subtype
+     */
+    public function setSubtype($subtype)
+    {
+        $this->subtype = $subtype;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubtype()
+    {
+        return $this->subtype;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getValue()
+    {
+        $subtype = ($this->subtype) ? '-' .$this->subtype : '';
+        return $this->type . $subtype;
+    }
+
+    public function setValue($value)
+    {
+        list($this->type, $this->subtype) = array_pad(explode('-', $value), 2, false);
+    }
+
+    public function __toString()
+    {
+        $parameters = (sizeof($this->parameters) > 0) ? ';' . http_build_query($this->getParameters(), null, ';') : '';
+
+        return $this->getValue() . ';q=' . $this->priority . $parameters;
+    }
+}


### PR DESCRIPTION
- Allow easier fetching of type/subtype for mimetypes and languages
- Allow mimetype params (aka accept params)

I'm not happy with some of this, specifically (but not limited to!):
- The way I figure out which value class to use
- The way ->getMedia() and the like return false
- The way __toString() vs ->getValue() work on the value objects; I wanted a way to do what was expected vs getting back the proper value. e.g. with mimetypes, you often want to do: if ($mimetype == 'application/json'), but when you're wanting to output the mimetype, you'd want the q-values and other parameters.
