### PR TITLE
Fix structure changes of files array

### DIFF
--- a/src/Request/Files.php
+++ b/src/Request/Files.php
@@ -60,9 +60,7 @@ class Files extends Values
             foreach ($srckeys as $key) {
                 if (is_array($src[$key])) {
                     // multiple file field names for each error, name, size, etc.
-                    foreach ((array) $src[$key] as $field => $value) {
-                        $tgt[$field][$key] = $value;
-                    }
+                    $this->prepareArray($value, $tgt, $key);
                 } else {
                     // the key itself is error, name, size, etc., and the
                     // target is already the file field name
@@ -74,6 +72,29 @@ class Files extends Values
             foreach ($src as $key => $val) {
                 $tgt[$key] = array();
                 $this->init($val, $tgt[$key]);
+            }
+        }
+    }
+    
+    /**
+     * Restructure multi dimensional array so that $last will be appended as last key
+     * 
+     * @param array $source
+     * @param array $target
+     */
+    protected function prepareArray(array $source, array &$target, $last)
+    {
+        foreach($source as $key => $value) {
+            if(!isset($target[$key])) {
+                $target[$key] = array();
+            }
+            
+            if(is_array($value)) {
+                $target[$key] = array();
+                $this->prepareArray($value, $target[$key], $last);
+            }
+            else {
+                $target[$key][$last] = $value;
             }
         }
     }


### PR DESCRIPTION
The restructuring of the `$_FILES` will fail if my uploaded file location has a various depth (e.g. `form[fields]['images']['header']`). The current implementation would create a result like this. It picks the first key of the path and uses it as field name.

``` php
array (
    'fields' => array(
        'name' => array(
            'images' => array(
                // ...
            )
        ),
        'tmp_name' => '...',
        'size' => '...',
    )
)
```

Instead I expect to get an array like this: 

``` php
array (
    'fields' => array(
        'images' => array(
            'header' => array(
                'name' => 'filename.txt',
                'tmp_name' => '...',
                'size' => '...',
            )
      )
)
```

This is what the PR will do.
