### PR TITLE
Changed host from 'HTTP_HOST' to 'SERVER_NAME'

### DIFF
--- a/src/Request/Url.php
+++ b/src/Request/Url.php
@@ -1,51 +1,51 @@
 <?php
 /**
- * 
+ *
  * This file is part of Aura for PHP.
- * 
+ *
  * @package Aura.Web
- * 
+ *
  * @license http://opensource.org/licenses/bsd-license.php BSD
- * 
+ *
  */
 namespace Aura\Web\Request;
 
 use Aura\Web\Exception;
 
 /**
- * 
+ *
  * A Url object from the server values passed
- * 
+ *
  * @package Aura.Web
- * 
+ *
  */
 class Url
 {
     /**
-     * 
+     *
      * @var string Url string
-     * 
+     *
      */
     protected $string;
-    
+
     /**
-     * 
+     *
      * @var array parts of the URL
-     * 
+     *
      */
     protected $parts;
-    
+
     /**
-     * 
+     *
      * @var bool Indicate whether the request is secure or not
-     * 
+     *
      */
     protected $secure;
-    
+
     /**
-     * 
+     *
      * @var array component constants, see http://php.net/parse-url
-     * 
+     *
      */
     protected $keys = array(
         PHP_URL_SCHEME      => 'scheme',
@@ -57,13 +57,13 @@ class Url
         PHP_URL_QUERY       => 'query',
         PHP_URL_FRAGMENT    => 'fragment',
     );
-    
+
     /**
-     * 
+     *
      * Constructor
-     * 
+     *
      * @param array An array of server values
-     * 
+     *
      */
     public function __construct(array $server)
     {
@@ -71,90 +71,102 @@ class Url
         $https = isset($server['HTTPS'])
                ? (strtolower($server['HTTPS']) == 'on')
                : false;
-        
+
         // explicit secure port?
         $port  = isset($server['SERVER_PORT'])
                ? ($server['SERVER_PORT'] == 443)
                : false;
-        
+
         // forwarded from an https scheme?
         $fwd   = isset($server['HTTP_X_FORWARDED_PROTO'])
                ? (strtolower($server['HTTP_X_FORWARDED_PROTO']) == 'https')
                : false;
-               
+
         // is this a secure request?
         $this->secure = ($https || $port || $fwd);
-        
+
         // pick the scheme
         $scheme = $this->secure
                 ? 'https://'
                 : 'http://';
-        
+
         // pick the host; we need to fake it on missing
         // hosts for parse_url() to work properly
         if (isset($server['HTTP_HOST'])) {
             $host = $server['HTTP_HOST'];
             $fake = false;
-        } else {
+        } elseif(isset($server['SERVER_NAME'])) {
+            $host = $server['SERVER_NAME'];
+            $fake = false;
+        } else  {
             $host = 'example.com';
             $fake = true;
         }
-        
+        preg_match('#\:[0-9]+$#', $host, $matches);
+        if ($matches) {
+            $found_port = array_pop($matches);
+            $host = substr($host, 0, -strlen($found_port));
+        }
+
         // pick the port
         $port   = isset($server['SERVER_PORT'])
                 ? ':' . $server['SERVER_PORT']
                 : null;
-        
+
+        if (is_null($port) && !empty($found_port)) {
+            $port = $found_port;
+        }
+
         // pick the uri
         $uri    = isset($server['REQUEST_URI'])
                 ? $server['REQUEST_URI']
                 : null;
-        
+
         // construct the URL string
         $this->string = $scheme . $host . $port . $uri;
-        
+
         // retain the URL parts
         $this->parts = parse_url($this->string);
-        
+
         // remove faked host
         if ($fake) {
             $this->parts[PHP_URL_HOST] = null;
         }
     }
-    
+
     /**
-     * 
-     * Returns the full URL string; 
+     *
+     * Returns the full URL string;
      * or, if a component constant is passed, returns only that part of the URL
-     * 
+     *
      * @param string $component
-     * 
+     *
      * @return string
-     * 
+     *
      */
     public function get($component = null)
     {
         if ($component === null) {
             return $this->string;
         }
-        
+
         if (! isset($this->keys[$component])) {
             throw new Exception\InvalidComponent($component);
         }
-        
+
         $key = $this->keys[$component];
         return isset($this->parts[$key])
              ? $this->parts[$key]
              : null;
     }
-    
+
     /**
-     * 
+     *
      * Indicates if the request is secure, whether via SSL, TLS, or
      * forwarded from a secure protocol
-     * 
+     *
      * @return bool
-     * 
+     *
      */
     public function isSecure()
     {

--- a/tests/src/Request/UrlTest.php
+++ b/tests/src/Request/UrlTest.php
@@ -42,46 +42,46 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function serverProvider()
     {
-        return [
-            [
+        return array(
+            array(
                 'http://example.com/foo?bar=baz',
-                [
+                array(
                     'HTTP_HOST'   => 'example.com',
                     'REQUEST_URI' => '/foo?bar=baz'
-                ]
-            ],
-            [
+                )
+            ),
+            array(
                 'http://example.com:1180/foo?bar=baz',
-                [
+                array(
                     'HTTP_HOST'   => 'example.com',
                     'SERVER_NAME' => 'example.com',
                     'SERVER_PORT' => '1180',
                     'REQUEST_URI' => '/foo?bar=baz'
-                ]
-            ],
-            [
+                )
+            ),
+            array(
                 'http://example.com:1180/foo?bar=baz',
-                [
+                array(
                     'SERVER_NAME' => 'example.com',
                     'SERVER_PORT' => '1180',
                     'REQUEST_URI' => '/foo?bar=baz'
-                ]
-            ],
-            [
+                )
+            ),
+            array(
                 'http://example.com:1180/foo?bar=baz',
-                [
+                array(
                     'HTTP_HOST'   => 'example.com:1180',
                     'REQUEST_URI' => '/foo?bar=baz'
-                ]
-            ],
-            [
+                )
+            ),
+            array(
                 'http://example.com:1180/foo?bar=baz',
-                [
+                array(
                     'SERVER_NAME' => 'example.com',
                     'SERVER_PORT' => '1180',
                     'REQUEST_URI' => '/foo?bar=baz'
-                ]
-            ]
-        ];
+                )
+            )
+        );
     }
 }

--- a/tests/src/Request/UrlTest.php
+++ b/tests/src/Request/UrlTest.php
@@ -7,36 +7,81 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         return new Url($server);
     }
-    
-    public function testGet()
+
+    /**
+     * @dataProvider serverProvider
+     */
+    public function testGet($expect, $server)
     {
-        $server['HTTP_HOST'] = 'example.com';
-        $server['REQUEST_URI'] = '/foo?bar=baz';
         $url = $this->newUrl($server);
-        
-        $expect = 'http://example.com/foo?bar=baz';
+
         $actual = $url->get();
         $this->assertSame($expect, $actual);
-        
+
         $expect = '/foo';
         $actual = $url->get(PHP_URL_PATH);
         $this->assertSame($expect, $actual);
-        
+
         $this->setExpectedException('Aura\Web\Exception');
         $url->get('no such component');
     }
-    
+
     public function testisSecure()
     {
         $url = $this->newUrl();
         $this->assertFalse($url->isSecure());
-        
+
         $server = array('HTTPS' => 'on');
         $url = $this->newUrl($server);
         $this->assertTrue($url->isSecure());
-        
+
         $server = array('SERVER_PORT' => '443');
         $url = $this->newUrl($server);
         $this->assertTrue($url->isSecure());
-    }    
+    }
+
+    public function serverProvider()
+    {
+        return [
+            [
+                'http://example.com/foo?bar=baz',
+                [
+                    'HTTP_HOST'   => 'example.com',
+                    'REQUEST_URI' => '/foo?bar=baz'
+                ]
+            ],
+            [
+                'http://example.com:1180/foo?bar=baz',
+                [
+                    'HTTP_HOST'   => 'example.com',
+                    'SERVER_NAME' => 'example.com',
+                    'SERVER_PORT' => '1180',
+                    'REQUEST_URI' => '/foo?bar=baz'
+                ]
+            ],
+            [
+                'http://example.com:1180/foo?bar=baz',
+                [
+                    'SERVER_NAME' => 'example.com',
+                    'SERVER_PORT' => '1180',
+                    'REQUEST_URI' => '/foo?bar=baz'
+                ]
+            ],
+            [
+                'http://example.com:1180/foo?bar=baz',
+                [
+                    'HTTP_HOST'   => 'example.com:1180',
+                    'REQUEST_URI' => '/foo?bar=baz'
+                ]
+            ],
+            [
+                'http://example.com:1180/foo?bar=baz',
+                [
+                    'SERVER_NAME' => 'example.com',
+                    'SERVER_PORT' => '1180',
+                    'REQUEST_URI' => '/foo?bar=baz'
+                ]
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
I ran into an issue where Url::get() was including the port twice `http://example.com:1180:1180/`. The value of `$_SERVER['HTTP_HOST']` is taken directly from the `Host: HTTP` request header and it appears some browsers (Chrome, in my case) include the port. `$_SERVER['SERVER_NAME']` gets its value from the virtual host config without the port.

Let me know if there is a better way of fixing this and I will amend the PR.
