### PR TITLE
Use proper MIME type for .csv extension

### DIFF
--- a/src/Request/Accept/Media.php
+++ b/src/Request/Accept/Media.php
@@ -61,7 +61,7 @@ class Media extends AbstractValues
         '.bmp'      => 'image/bmp',
         '.c'        => 'text/plain',
         '.css'      => 'text/css',
-        '.csv'      => 'text/plain',
+        '.csv'      => 'text/csv',
         '.dtd'      => 'application/xml-dtd',
         '.etx'      => 'text/x-setext',
         '.flr'      => 'x-world/x-vrml',


### PR DESCRIPTION
text/csv is the right MIME type, according to http://www.freeformatter.com/mime-types-list.html
