### PR TITLE
Add autoloa-der so unit tests can help

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,12 @@
             "Aura\\Web\\_Config\\": "config/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Aura\\Web\\": "tests/unit/src/",
+            "Aura\\Web\\_Config\\": "tests/container/src/"
+        }
+    },
     "extra": {
         "aura": {
             "type": "library",


### PR DESCRIPTION
I added this for it may help us in running phpunit for testing the web-kernel and all rather than requiring it in bootstrap.php , but as it is a function I think it is not useful in that case.

But still in case if you prefer so others can make use of the tests ?
