### PR TITLE
Fix example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ example:
 use Aura\Web\WebFactory;
 
 $web_factory = new WebFactory(compact(
-    $_ENV,
-    $_GET,
-    $_POST,
-    $_COOKIE,
-    $_SERVER
+    '_ENV',
+    '_GET',
+    '_POST',
+    '_COOKIE',
+    '_SERVER'
 ));
 $request = $web_factory->newRequest();
 $response = $web_factory->newResponse();


### PR DESCRIPTION
The [compact](http://php.net/manual/en/function.compact.php) function accepts the names of variables as strings not the variables themselves.
