### PR TITLE
more like a suggestion...

### DIFF
--- a/src/Request/Values.php
+++ b/src/Request/Values.php
@@ -71,17 +71,22 @@ class Values extends ArrayObject
      * not set.
      *
      */
-    public function get($key = null, $alt = null)
+    public function get($key, $alt = null)
     {
-        if (! $key) {
-            return $this->getArrayCopy();
-        }
+        return isset($this[$key]) ? $this[$key] : $alt;
+    }
 
-        if (isset($this[$key])) {
-            return $this[$key];
-        }
 
-        return $alt;
+    /**
+     *
+     * Returns all the values as an array.
+     *
+     * @return array 
+     *
+     */
+    public function all()
+    {
+        return $this->getArrayCopy();
     }
 
     /**


### PR DESCRIPTION
...than a PR

I believe that a method named all() has a more semantic meaning for retrieving all the values, get() should be used to always fetch a single key value....of course this would be a possibly bc breaking change in the public interface.
