### PR TITLE
Support multiple header values.

### DIFF
--- a/README-RESPONSE.md
+++ b/README-RESPONSE.md
@@ -82,11 +82,11 @@ $response->headers->set('X-Header-Value', 'foo');
 $response->headers->add('X-Header-Value-Many', 'foo');
 $response->headers->add('X-Header-Value-Many', 'bar');
 
-// get the X-Header-Value (returns a string)
+// get the X-Header-Value (returns a string: 'foo')
 $value = $response->headers->get('X-Header-Value');
 
-// get the X-Header-Value-Many (returns an array)
-$value = $response->headers->get('X-Header-Value');
+// get the X-Header-Value-Many (returns an array: ['foo', 'bar'])
+$value = $response->headers->get('X-Header-Value-Many');
 
 // get all headers
 $all_headers = $response->headers->get();

--- a/README-RESPONSE.md
+++ b/README-RESPONSE.md
@@ -69,6 +69,8 @@ The `$response->headers` object has these methods:
 
 - `set()` to set a single header, resetting previous values on that header
 
+- `add()` add to a header, appending another value to the that header
+
 - `get()` to get a single header, or to get all headers
 
 ```php
@@ -76,7 +78,14 @@ The `$response->headers` object has these methods:
 // X-Header-Value: foo
 $response->headers->set('X-Header-Value', 'foo');
 
-// get the X-Header-Value
+// X-Header-Value-Many: foo
+$response->headers->add('X-Header-Value-Many', 'foo');
+$response->headers->add('X-Header-Value-Many', 'bar');
+
+// get the X-Header-Value (returns a string)
+$value = $response->headers->get('X-Header-Value');
+
+// get the X-Header-Value-Many (returns an array)
 $value = $response->headers->get('X-Header-Value');
 
 // get all headers
@@ -274,7 +283,13 @@ header($response->status->get(), true, $response->status->getCode());
 
 // send non-cookie headers
 foreach ($response->headers->get() as $label => $value) {
-    header("{$label}: {$value}");
+    if (is_array($value)) {
+        foreach ($value as $val) {
+            header("{$label}: {$value}", false);
+        }
+    } else {
+        header("{$label}: {$value}");
+    }
 }
 
 // send cookies

--- a/README-RESPONSE.md
+++ b/README-RESPONSE.md
@@ -285,7 +285,7 @@ header($response->status->get(), true, $response->status->getCode());
 foreach ($response->headers->get() as $label => $value) {
     if (is_array($value)) {
         foreach ($value as $val) {
-            header("{$label}: {$value}", false);
+            header("{$label}: {$val}", false);
         }
     } else {
         header("{$label}: {$value}");

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -75,7 +75,7 @@ class Headers
                 if (is_array($current)) {
                     $this->headers[$label][] = $value;
                 } else {
-                    $this->headers[$label] = [$current, $value];
+                    $this->headers[$label] = array($current, $value);
                 }
             } else {
                 $this->headers[$label] = $value;

--- a/src/Response/Headers.php
+++ b/src/Response/Headers.php
@@ -55,11 +55,41 @@ class Headers
 
     /**
      *
+     * Appends a header value in `$headers`.
+     *
+     * @param string $label The header label.
+     *
+     * @param string $value The value for the header; an empty-string/null/
+     * false value will unset the header (although a zero will not).
+     *
+     * @return null
+     *
+     */
+    public function add($label, $value)
+    {
+        $label = $this->sanitizeLabel($label);
+        $value = $this->sanitizeValue($value);
+        if ($value !== '') {
+            if (isset($this->headers[$label])) {
+                $current = $this->headers[$label];
+                if (is_array($current)) {
+                    $this->headers[$label][] = $value;
+                } else {
+                    $this->headers[$label] = [$current, $value];
+                }
+            } else {
+                $this->headers[$label] = $value;
+            }
+        }
+    }
+
+    /**
+     *
      * Returns the value of a single header, or all headers.
      *
      * @param string $label The header name.
      *
-     * @return string The header value.
+     * @return string|string[] The header value(s).
      *
      */
     public function get($label = null)

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -46,7 +46,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         // get all
         $expect = array(
           'Foo-Bar' => 'baz',
-          'Dib' => ['zim', 'zam'],
+          'Dib' => array('zim', 'zam'),
         );
         $actual = $this->headers->get();
         $this->assertSame($expect, $actual);

--- a/tests/Response/HeadersTest.php
+++ b/tests/Response/HeadersTest.php
@@ -31,4 +31,24 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         // no such header
         $this->assertNull($this->headers->get('no-such-header'));
     }
+
+    public function testAddAndGet()
+    {
+        $this->headers->add('foo-bar', 'baz');
+        $this->headers->add('dib', 'zim');
+        $this->headers->add('dib', 'zam');
+
+        // get one
+        $expect = 'baz';
+        $actual = $this->headers->get('foo-bar');
+        $this->assertSame($expect, $actual);
+
+        // get all
+        $expect = array(
+          'Foo-Bar' => 'baz',
+          'Dib' => ['zim', 'zam'],
+        );
+        $actual = $this->headers->get();
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
Added `Response/Headers::add` to give the ability to set multiple values for a given header.
