### PR TITLE
Fix parsing for urlencoded body

### DIFF
--- a/src/Request/Content.php
+++ b/src/Request/Content.php
@@ -24,14 +24,7 @@ class Content
      * @var array
      *
      */
-    protected $decoders = array(
-        'application/json' => 'json_decode',
-        'application/x-www-form-urlencoded' => function($body)
-        {
-          parse_str($body, $output);
-          return $output;
-        },
-    );
+    protected $decoders;
 
     /**
      *
@@ -98,7 +91,14 @@ class Content
                    ? strtolower($server['HTTP_CONTENT_MD5'])
                    : null;
 
-        $this->decoders = array_merge($this->decoders, $decoders);
+        $this->decoders = array_merge(array(
+          'application/json' => 'json_decode',
+          'application/x-www-form-urlencoded' => function($body)
+            {
+              parse_str($body, $output);
+              return $output;
+            },
+        ), $decoders);
     }
 
     /**

--- a/src/Request/Content.php
+++ b/src/Request/Content.php
@@ -26,7 +26,11 @@ class Content
      */
     protected $decoders = array(
         'application/json' => 'json_decode',
-        'application/x-www-form-urlencoded' => 'parse_str',
+        'application/x-www-form-urlencoded' => function($body)
+        {
+          parse_str($body, $output);
+          return $output;
+        },
     );
 
     /**


### PR DESCRIPTION
This fixes an issue where the default decoder for "x-www-form-urlencoded" was not directly returning data. The reason is due to the implementation of `parse_str()`. See http://php.net/manual/en/function.parse-str.php. Since, the 2nd parameter of `parse_str()` is a reference variable, it can't be returned directly as the decoders array is implemented.