### PR TITLE
Add empty string as alternative value to HTTP_X_REQUESTED_WITH

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -207,7 +207,7 @@ class Request
         $this->server  = $globals->server;
         $this->url     = $url;
 
-        $with = strtolower($this->server->get('HTTP_X_REQUESTED_WITH'));
+        $with = strtolower($this->server->get('HTTP_X_REQUESTED_WITH', ''));
         if ($with == 'xmlhttprequest') {
             $this->xhr = true;
         }


### PR DESCRIPTION
Add empty string as alternative value to `$this->server->get('HTTP_X_REQUESTED_WITH')` because `strtolower()` does not accept null if HTTP_X_REQUESTED_WITH is not set.